### PR TITLE
chore: add fetch timeout handler

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -6,7 +6,8 @@ enum ErrorName {
   SIGNATURE_ERROR = 'SignatureError',
   TOKEN_ERROR = 'TokenError',
   SOCKET_CONNECTION_ERROR = 'SocketConnectionError',
-  SOCKET_EMIT_ERROR = 'SocketEmitError'
+  SOCKET_EMIT_ERROR = 'SocketEmitError',
+  TIMEOUT_ERROR = 'TimeoutError'
 }
 
 export class ValidationError extends Error {
@@ -73,5 +74,14 @@ export class SocketEmitError extends Error {
   constructor(message: string, public details?: any) {
     super(message);
     this.name = ErrorName.SOCKET_EMIT_ERROR;
+  }
+}
+
+export class TimeoutError extends Error {
+  static name = 'TimeoutError';
+
+  constructor(message: string, public details?: any) {
+    super(message);
+    this.name = ErrorName.TIMEOUT_ERROR;
   }
 }

--- a/lib/relaybox.ts
+++ b/lib/relaybox.ts
@@ -54,10 +54,8 @@ const AUTH_TOKEN_LIFECYCLE_EXPIRY = 'expiry';
  */
 const DEFAULT_OFFLINE_AUTH_HOST = 'http://localhost';
 const DEFAULT_OFFLINE_AUTH_PATH = 'auth';
-
 const DEFAULT_OFFLINE_CORE_HOST = 'ws://localhost';
 const DEFAULT_OFFLINE_CORE_PATH = 'core';
-
 const DEFAULT_OFFLINE_PORT = 9000;
 
 /**

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -2,6 +2,7 @@ import { HTTPRequestError, HTTPServiceError, NetworkError } from './errors';
 import { ApiData, FormattedResponse } from './types/request.types';
 
 const NODE_FETCH_ERR_MESSAGES = ['Failed to fetch'];
+const DEFAULT_REQUEST_TIMEOUT = 10000;
 
 async function formatResponse<T>(response: Response): Promise<FormattedResponse<T & ApiData>> {
   const data = <T & ApiData>await response.json();
@@ -22,7 +23,8 @@ export async function request<T>(
   try {
     response = await fetch(url, {
       ...params,
-      cache: 'no-store'
+      cache: 'no-store',
+      signal: AbortSignal.timeout(1)
     });
 
     if (!response.ok) {
@@ -45,7 +47,8 @@ export async function serviceRequest<T>(url: URL | string, params: RequestInit):
   try {
     const response = await fetch(url, {
       ...params,
-      cache: 'no-store'
+      cache: 'no-store',
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT)
     });
 
     const data = <T & ApiData>await response.json();

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -30,6 +30,10 @@ export async function request<T>(
     if (!response.ok) {
       throw new HTTPRequestError(`${response.status} ${response.statusText}`, response.status);
     }
+
+    const formattedResponse = await formatResponse<T>(response);
+
+    return formattedResponse;
   } catch (err: unknown) {
     if (err instanceof TypeError && NODE_FETCH_ERR_MESSAGES.includes(err.message)) {
       throw new NetworkError('Network request failed: Unable to connect to the server', 0);
@@ -39,10 +43,6 @@ export async function request<T>(
 
     throw err;
   }
-
-  const formattedResponse = await formatResponse<T>(response);
-
-  return formattedResponse;
 }
 
 export async function serviceRequest<T>(url: URL | string, params: RequestInit): Promise<T> {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -35,9 +35,9 @@ export async function request<T>(
       throw new NetworkError('Network request failed: Unable to connect to the server', 0);
     } else if (err instanceof DOMException && err.name === TimeoutError.name) {
       throw new TimeoutError(err.message);
-    } else {
-      throw err;
     }
+
+    throw err;
   }
 
   const formattedResponse = await formatResponse<T>(response);

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -2,7 +2,7 @@ import { HTTPRequestError, HTTPServiceError, NetworkError, TimeoutError } from '
 import { ApiData, FormattedResponse } from './types/request.types';
 
 const NODE_FETCH_ERR_MESSAGES = ['Failed to fetch'];
-const DEFAULT_REQUEST_TIMEOUT = 10000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
 
 async function formatResponse<T>(response: Response): Promise<FormattedResponse<T & ApiData>> {
   const data = <T & ApiData>await response.json();
@@ -50,7 +50,7 @@ export async function serviceRequest<T>(url: URL | string, params: RequestInit):
     const response = await fetch(url, {
       ...params,
       cache: 'no-store',
-      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT)
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS)
     });
 
     const data = <T & ApiData>await response.json();

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,4 +1,4 @@
-import { HTTPRequestError, HTTPServiceError, NetworkError } from './errors';
+import { HTTPRequestError, HTTPServiceError, NetworkError, TimeoutError } from './errors';
 import { ApiData, FormattedResponse } from './types/request.types';
 
 const NODE_FETCH_ERR_MESSAGES = ['Failed to fetch'];
@@ -33,6 +33,8 @@ export async function request<T>(
   } catch (err: unknown) {
     if (err instanceof TypeError && NODE_FETCH_ERR_MESSAGES.includes(err.message)) {
       throw new NetworkError('Network request failed: Unable to connect to the server', 0);
+    } else if (err instanceof DOMException && err.name === TimeoutError.name) {
+      throw new TimeoutError(err.message);
     } else {
       throw err;
     }
@@ -61,6 +63,8 @@ export async function serviceRequest<T>(url: URL | string, params: RequestInit):
   } catch (err: unknown) {
     if (err instanceof TypeError && NODE_FETCH_ERR_MESSAGES.includes(err.message)) {
       throw new NetworkError('Network request failed: Unable to connect to the server', 0);
+    } else if (err instanceof DOMException && err.name === TimeoutError.name) {
+      throw new TimeoutError(err.message);
     } else {
       throw err;
     }

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -24,7 +24,7 @@ export async function request<T>(
     response = await fetch(url, {
       ...params,
       cache: 'no-store',
-      signal: AbortSignal.timeout(1)
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS)
     });
 
     if (!response.ok) {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -14,7 +14,7 @@ import { AuthEvent } from '../lib/types';
 import { SocketManager } from '../lib/socket-manager';
 import { User } from '../lib/user';
 
-const mockPublicKey = 'appId.keyId';
+const mockPublicKey = 'appPid.keyId';
 const mockCoreServiceUrl = process.env.CORE_SERVICE_URL || '';
 const mockAuthServiceUrl = process.env.AUTH_SERVICE_URL || '';
 const mockAuthServiceHost = 'http://localhost:9090';

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -89,11 +89,7 @@ describe('request', () => {
     it('should throw TimeoutError when request times out', async () => {
       vi.useFakeTimers();
 
-      server.use(
-        http.get(mockUrl, () => {
-          return HttpResponse.error();
-        })
-      );
+      server.use(http.get(mockUrl, () => HttpResponse.json(mockResponse)));
 
       const requestParams = {
         method: HttpMethod.GET
@@ -173,11 +169,7 @@ describe('serviceRequest', () => {
     it('should throw TimeoutError when request times out', async () => {
       vi.useFakeTimers();
 
-      server.use(
-        http.get(mockUrl, () => {
-          return HttpResponse.error();
-        })
-      );
+      server.use(http.get(mockUrl, () => HttpResponse.json(mockResponse)));
 
       const requestParams = {
         method: HttpMethod.GET

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -95,11 +95,11 @@ describe('request', () => {
         method: HttpMethod.GET
       };
 
-      const promise = serviceRequest(mockUrl, requestParams);
+      const requestPromise = serviceRequest(mockUrl, requestParams);
 
       vi.advanceTimersByTime(10000);
 
-      await expect(promise).rejects.toThrow(TimeoutError);
+      await expect(requestPromise).rejects.toThrow(TimeoutError);
     });
   });
 });
@@ -175,11 +175,11 @@ describe('serviceRequest', () => {
         method: HttpMethod.GET
       };
 
-      const promise = serviceRequest(mockUrl, requestParams);
+      const requestPromise = serviceRequest(mockUrl, requestParams);
 
       vi.advanceTimersByTime(10000);
 
-      await expect(promise).rejects.toThrow(TimeoutError);
+      await expect(requestPromise).rejects.toThrow(TimeoutError);
     });
   });
 });

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -89,7 +89,7 @@ describe('request', () => {
     it('should throw TimeoutError when request times out', async () => {
       vi.useFakeTimers();
 
-      server.use(http.get(mockUrl, () => HttpResponse.json(mockResponse)));
+      server.use(http.get(mockUrl, () => new Promise(() => {})));
 
       const requestParams = {
         method: HttpMethod.GET
@@ -169,7 +169,7 @@ describe('serviceRequest', () => {
     it('should throw TimeoutError when request times out', async () => {
       vi.useFakeTimers();
 
-      server.use(http.get(mockUrl, () => HttpResponse.json(mockResponse)));
+      server.use(http.get(mockUrl, () => new Promise(() => {})));
 
       const requestParams = {
         method: HttpMethod.GET


### PR DESCRIPTION
- Adds `fetch` abort signal timeout handler with default `10000ms`
- Adds tests to `request.test.ts` accordingly